### PR TITLE
Render markdown in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,68 @@
-# ActionMarkdown
-Short description and motivation.
+# Welcome to ActionMarkdown
 
-## Usage
-How to use my plugin.
+Do you like GitHub issues Markdown editor? I love it too! ActionMarkdown aims to provide the same feature out of the box for Rails applications. With ActionMarkdown, it is easy to write some Markdown text in a form field and convert it to HTML seamlessly in the view.
 
 ## Installation
-Add this line to your application's Gemfile:
+
+Let's add this line to our application's `Gemfile`:
 
 ```ruby
 gem "action_markdown"
 ```
 
-And then execute:
+We can then run the installation script to copy the migration file:
+
 ```bash
-$ bundle
+bin/rails action_markdown:install
 ```
 
-Or install it yourself as:
+Last but not least, we need to run the migration:
+
 ```bash
-$ gem install action_markdown
+bin/rails db:migrate
 ```
 
-## Contributing
-Contribution directions go here.
+ActionMarkdown is now installed, we are good to go!
+
+## Usage
+
+Let's imagine we want to write articles in the Markdown format. In our Rails application, we will have an `Article`. To add Markdown content, we need to use the `has_markdown` macro like this:
+
+```rb
+class Article < ApplicationRecord
+  has_markdown :content
+
+  validates :content, presence: true
+end
+```
+
+Without adding any new migration, we can now create a new article with Markdown text:
+
+```rb
+markdown = <<~MARKDOWN
+# Title
+
+This is a paragraph.
+MARKDOWN
+
+article = Article.create! content: markdown
+```
+
+In the view, the Markdown content will be converted to HTML. For example, in the `ArticlesController#show` view, we can render the content converted to HTML like this:
+
+```erb
+<%# articles/show.html.erb %>
+
+<%= @article.content %>
+```
+
+In the view above, the Markdown content will automatically be converted to the following HTML:
+
+```html
+<h1>Title</h1>
+<p>This is a paragraph.</p>
+```
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/views/action_markdown/contents/_content.html.erb
+++ b/app/views/action_markdown/contents/_content.html.erb
@@ -1,0 +1,1 @@
+<%= sanitize content.to_html %>

--- a/lib/action_markdown.rb
+++ b/lib/action_markdown.rb
@@ -9,5 +9,6 @@ module ActionMarkdown
   autoload :Attribute
   autoload :Content
   autoload :Renderer
+  autoload :Rendering
   autoload :Serialization
 end

--- a/lib/action_markdown/content.rb
+++ b/lib/action_markdown/content.rb
@@ -1,25 +1,25 @@
 module ActionMarkdown
   class Content
-    include Serialization
+    include ActiveModel::Conversion, Rendering, Serialization
 
     def initialize(body)
       @body = body
     end
 
     def to_html
-      renderer.render(body).strip
+      markdown_renderer.render(body)
     end
 
     def to_s
-      to_html
+      render partial: to_partial_path, layout: false, locals: { content: self }
     end
 
     private
 
     attr_accessor :body
 
-    def renderer
-      @renderer ||= Redcarpet::Markdown.new(
+    def markdown_renderer
+      @markdown_renderer ||= Redcarpet::Markdown.new(
         Renderer,
         no_intra_emphasis: true,
         fenced_code_blocks: true,

--- a/lib/action_markdown/rendering.rb
+++ b/lib/action_markdown/rendering.rb
@@ -1,0 +1,13 @@
+module ActionMarkdown
+  module Rendering
+    private
+
+    def render(*args, &block)
+      action_controller_renderer.render(*args, &block)
+    end
+
+    def action_controller_renderer
+      ActionController::Base.renderer
+    end
+  end
+end

--- a/test/models/attribute_test.rb
+++ b/test/models/attribute_test.rb
@@ -1,23 +1,23 @@
 require "test_helper"
 
-class ActionMarkdown::AttributeTest < ActiveSupport::TestCase
+class ActionMarkdown::AttributeTest < ActionView::TestCase
   test "Instantiating an article with Markdown content converts it to HML" do
     article = Article.new content: "# Title"
 
-    assert_equal %q(<h1>Title</h1>), article.content.to_s
+    assert_dom_equal %q(<h1>Title</h1>), article.content.to_s.strip
   end
 
   test "Instanciating an article without Markdown content returns an empty string" do
-    assert_equal "", Article.new.content.to_s
+    assert_dom_equal "", Article.new.content.to_s.strip
   end
 
   test "Creating an article with Markdown content converts it to HML" do
     article = Article.create! content: "# Title"
 
-    assert_equal %q(<h1>Title</h1>), article.content.to_s
+    assert_dom_equal %q(<h1>Title</h1>), article.content.to_s.strip
   end
 
   test "Creating an article without Markdown content returns an empty string" do
-    assert_equal "", Article.create!.content.to_s
+    assert_dom_equal "", Article.create!.content.to_s.strip
   end
 end

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -2,10 +2,14 @@ require "test_helper"
 
 class ActionMarkdown::ContentTest < ActiveSupport::TestCase
   test "#to_html converts the Markdown body to HTML" do
-    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_html
+    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_html.strip
   end
 
   test "#to_s converts the Markdown body to HTML" do
-    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_s
+    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_s.strip
+  end
+
+  test "#to_s properly sanitizes generated HTML" do
+    assert_equal 'alert("hello")', ActionMarkdown::Content.new('<script>alert("hello")</script>').to_s.strip
   end
 end


### PR DESCRIPTION
It is now possible to render Markdown converted to HTML directly in the view:

```erb
<%# articles/show.html.erb %>

<%= @article.content %>
```

Under the hood, this calls the `#to_s` method on the `ActionMarkdown::Content` instance that renders a partial containing the following code:

```erb
<%# action_markdown/contents/_content.html.erb %>

<%= sanitize content.to_html %>
```

The output HTML is sanitized by Rails.