### PR TITLE
Rename RichText to MarkdownText

### DIFF
--- a/app/models/action_markdown/markdown_text.rb
+++ b/app/models/action_markdown/markdown_text.rb
@@ -1,6 +1,6 @@
 module ActionMarkdown
-  class RichText < ApplicationRecord
-    self.table_name = "action_markdown_rich_texts"
+  class MarkdownText < ApplicationRecord
+    self.table_name = "action_markdown_markdown_texts"
 
     serialize :body, ActionMarkdown::Content
 

--- a/db/migrate/20221110163240_create_action_markdown_tables.rb
+++ b/db/migrate/20221110163240_create_action_markdown_tables.rb
@@ -3,14 +3,14 @@ class CreateActionMarkdownTables < ActiveRecord::Migration[7.0]
     # Use Active Record's configured type for primary and foreign keys
     primary_key_type, foreign_key_type = primary_and_foreign_key_types
 
-    create_table :action_markdown_rich_texts, id: primary_key_type do |t|
+    create_table :action_markdown_markdown_texts, id: primary_key_type do |t|
       t.string     :name, null: false
       t.text       :body, size: :long
       t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
 
       t.timestamps
 
-      t.index %i[record_type record_id name], name: "index_action_markdown_rich_texts_uniqueness", unique: true
+      t.index %i[record_type record_id name], name: "index_action_markdown_markdown_texts_uniqueness", unique: true
     end
   end
 

--- a/lib/action_markdown/attribute.rb
+++ b/lib/action_markdown/attribute.rb
@@ -11,7 +11,7 @@ module ActionMarkdown
         end
       CODE
 
-      has_one :"markdown_#{name}", -> { where(name: name) }, class_name: "ActionMarkdown::RichText",
+      has_one :"markdown_#{name}", -> { where(name: name) }, class_name: "ActionMarkdown::MarkdownText",
         as: :record, inverse_of: :record, autosave: true, dependent: :destroy
 
       scope :"with_markdown_#{name}", -> { includes("markdown_#{name}") }

--- a/lib/action_markdown/serialization.rb
+++ b/lib/action_markdown/serialization.rb
@@ -15,7 +15,7 @@ module ActionMarkdown
           nil
         when self
           content.to_html
-        when ActionMarkdown::RichText
+        when ActionMarkdown::MarkdownText
           content.body.to_html
         else
           new(content).to_html

--- a/test/dummy/db/migrate/20221110172331_create_action_markdown_tables.action_markdown.rb
+++ b/test/dummy/db/migrate/20221110172331_create_action_markdown_tables.action_markdown.rb
@@ -4,14 +4,14 @@ class CreateActionMarkdownTables < ActiveRecord::Migration[7.0]
     # Use Active Record's configured type for primary and foreign keys
     primary_key_type, foreign_key_type = primary_and_foreign_key_types
 
-    create_table :action_markdown_rich_texts, id: primary_key_type do |t|
+    create_table :action_markdown_markdown_texts, id: primary_key_type do |t|
       t.string     :name, null: false
       t.text       :body, size: :long
       t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
 
       t.timestamps
 
-      t.index %i[record_type record_id name], name: "index_action_markdown_rich_texts_uniqueness", unique: true
+      t.index %i[record_type record_id name], name: "index_action_markdown_markdown_texts_uniqueness", unique: true
     end
   end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,14 +11,14 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_10_172511) do
-  create_table "action_markdown_rich_texts", force: :cascade do |t|
+  create_table "action_markdown_markdown_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["record_type", "record_id", "name"], name: "index_action_markdown_rich_texts_uniqueness", unique: true
+    t.index ["record_type", "record_id", "name"], name: "index_action_markdown_markdown_texts_uniqueness", unique: true
   end
 
   create_table "articles", force: :cascade do |t|


### PR DESCRIPTION
The `rich_text` naming was wrong because the `rich_text` is actually `markdown_text`.