### PR TITLE
Make presence validations work

### DIFF
--- a/app/models/action_markdown/markdown_text.rb
+++ b/app/models/action_markdown/markdown_text.rb
@@ -6,6 +6,11 @@ module ActionMarkdown
 
     belongs_to :record, polymorphic: true, touch: true
 
-    delegate :to_s, :to_html, to: :body
+    delegate :to_s, :nil?, to: :body
+    delegate :blank?, :empty?, :present?, to: :to_html
+
+    def to_html
+      body&.to_html.to_s
+    end
   end
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,3 +1,5 @@
 class Article < ApplicationRecord
   has_markdown :content
+
+  validates :content, presence: true, on: :content_presence
 end

--- a/test/models/attribute_test.rb
+++ b/test/models/attribute_test.rb
@@ -20,4 +20,28 @@ class ActionMarkdown::AttributeTest < ActionView::TestCase
   test "Creating an article without Markdown content returns an empty string" do
     assert_dom_equal "", Article.create!.content.to_s.strip
   end
+
+  test "An article where content is optional is valid with no content" do
+    assert Article.new.valid?
+  end
+
+  test "An article where content is required is invalid without a content" do
+    assert Article.new.invalid?(:content_presence)
+  end
+
+  test "An article with an empty content has an empty content" do
+    assert Article.new.content.empty?
+  end
+
+  test "An article with a blank content has a blank content" do
+    assert Article.new(content: " ").content.blank?
+  end
+
+  test "An article without a content has a non present content" do
+    assert_not Article.new.content.present?
+  end
+
+  test "An article without content has a nil content" do
+    assert Article.new.content.nil?
+  end
 end


### PR DESCRIPTION
We want to be able to do:

```rb
class Article < ApplicationRecord
  has_markdown :content

  validates :content, presence: true
end
```

When calling `Article.new.content`, we get an instance of `ActionMarkdown::MarkdownText` that is `present?` by default. To solve this problem, we delegate `#present?`, but also `#blank?` and `#empty?` to `ActionMarkdown::MarkdownText#to_html`.