### PR TITLE
Add default stylesheet to style Markdown content

### DIFF
--- a/app/assets/stylesheets/action_markdown/action_markdown.css
+++ b/app/assets/stylesheets/action_markdown/action_markdown.css
@@ -1,0 +1,313 @@
+.action-markdown {
+  /* Inline code variables */
+  --am-inline-code-padding-y: 0.15rem;
+  --am-inline-code-padding-x: 0.2rem;
+  --am-inline-code-border-radius: 0.375rem;
+  --am-inline-code-background: hsl(53 100% 65% / 0.2);
+
+  /* Code block paddings */
+  --am-code-padding-y: 1rem;
+  --am-code-padding-x: 1.5rem;
+
+  /* Code block border-radius */
+  --am-code-border-radius: 0.5rem;
+
+  /* Code block shadow */
+  --am-code-shadow: 1px 3px 6px hsl(0 0% 0% / 0.1);
+
+  /* Code syntax highlighting variables */
+  --am-code-background:hsl(208 95% 8%);
+  --am-code-comment:   hsl(180 9% 43%);
+  --am-code-string:    hsl(35 71% 74%);
+  --am-code-inherit:   hsl(77 67% 68%);
+  --am-code-number:    hsl(14 90% 70%);
+  --am-code-error:     hsl(357 79% 65%);
+  --am-code-constant:  hsl(221 100% 75%);
+  --am-code-keyword:   hsl(276 68% 75%);
+  --am-code-class:     hsl(33 100% 77%);
+  --am-code-variable:  hsl(169 56% 68%);
+  --am-code-text:      hsl(217 34% 88%);
+  --am-code-html:      hsl(169 47% 86%);
+}
+
+.action-markdown p code,
+.action-markdown li code {
+  color: inherit;
+  border-radius: var(--am-inline-code-border-radius);
+  background-color: var(--am-inline-code-background);
+  padding: var(--am-inline-code-padding-y) var(--am-inline-code-padding-x);
+}
+
+.action-markdown div.highlight {
+  overflow: auto;
+  background-color: var(--am-code-background);
+  border-radius: var(--am-code-border-radius);
+  box-shadow: var(--am-code-shadow);
+}
+
+.action-markdown pre.highlight {
+  margin: 0;
+  float: left;
+  padding: var(--am-code-padding-y) var(--am-code-padding-x);
+}
+
+.action-markdown .highlight code {
+  color: var(--am-code-text);
+}
+
+.action-markdown .highlight .cm {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .p {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .cp {
+  color: var(--am-code-error);
+}
+
+.action-markdown .highlight .c1 {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .cs {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .c,
+.action-markdown .highlight .ch,
+.action-markdown .highlight .cd,
+.action-markdown .highlight .cpf {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .err {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .gd {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .ge {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .gr {
+  color: var(--am-code-error);
+}
+
+.action-markdown .highlight .gh {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .gi {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .go {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .gp {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .gu {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .gt {
+  color: var(--am-code-error);
+}
+.action-markdown .highlight .kc {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .kd {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .kn {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .kp {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .kr {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .kt {
+  color: var(--am-code-class);
+}
+
+.action-markdown .highlight .k,
+.action-markdown .highlight .kv {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .mf {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .mh {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .il {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .mi {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .mo {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .m,
+.action-markdown .highlight .mb,
+.action-markdown .highlight .mx {
+  color: var(--am-code-number);
+}
+
+.action-markdown .highlight .sa {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .sb {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .sc {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .sd {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .s2 {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .se {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .sh {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .si {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .sx {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .sr {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .s1 {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .ss {
+  color: var(--am-code-variable);
+}
+
+.action-markdown .highlight .s,
+.action-markdown .highlight .dl {
+  color: var(--am-code-string);
+}
+
+.action-markdown .highlight .na {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .bp {
+  color: var(--am-code-comment);
+}
+
+.action-markdown .highlight .nb {
+  color: var(--am-code-text);
+}
+
+.action-markdown .highlight .nc {
+  color: var(--am-code-class);
+}
+
+.action-markdown .highlight .no {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .nd {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .ni {
+  color: var(--am-code-constant);
+}
+
+.action-markdown .highlight .ne {
+  color: var(--am-code-constant);
+}
+
+.action-markdown .highlight .nf,
+.action-markdown .highlight .fm {
+  color: var(--am-code-constant);
+}
+
+.action-markdown .highlight .nl {
+  color: var(--am-code-constant);
+}
+
+.action-markdown .highlight .nn {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .nt {
+  color: var(--am-code-html);
+}
+
+.action-markdown .highlight .n,
+.action-markdown .highlight .p {
+  color: var(--am-code-text);
+}
+
+.action-markdown .highlight .vc {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .vg {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .vi {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .nv,
+.action-markdown .highlight .vm {
+  color: var(--am-code-inherit);
+}
+
+.action-markdown .highlight .ow {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .o {
+  color: var(--am-code-keyword);
+}
+
+.action-markdown .highlight .w {
+  color: var(--am-code-comment);
+}

--- a/app/views/action_markdown/contents/_content.html.erb
+++ b/app/views/action_markdown/contents/_content.html.erb
@@ -1,1 +1,3 @@
-<%= sanitize content.to_html %>
+<div class="action-markdown">
+  <%= sanitize content.to_html %>
+</div>

--- a/lib/action_markdown.rb
+++ b/lib/action_markdown.rb
@@ -2,6 +2,7 @@ require "action_markdown/version"
 require "action_markdown/engine"
 
 require "redcarpet"
+require "rouge"
 
 module ActionMarkdown
   extend ActiveSupport::Autoload

--- a/lib/generators/action_markdown/install/install_generator.rb
+++ b/lib/generators/action_markdown/install/install_generator.rb
@@ -1,8 +1,22 @@
 module ActionMarkdown
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
+      source_root ActionMarkdown::Engine.root
+
       def create_migrations
         rails_command "railties:install:migrations FROM=action_markdown", inline: true
+      end
+
+      def create_action_markdown_files
+        copy_file(
+          "app/assets/stylesheets/action_markdown/action_markdown.css",
+          "app/assets/stylesheets/action_markdown.css"
+        )
+
+        copy_file(
+          "app/views/action_markdown/contents/_content.html.erb",
+          "app/views/action_markdown/contents/_content.html.erb"
+        )
       end
     end
   end

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link action_markdown/action_markdown.css

--- a/test/dummy/app/assets/stylesheets/application.css
+++ b/test/dummy/app/assets/stylesheets/application.css
@@ -1,15 +1,19 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.5;
+}
+
+.container {
+  max-width: 80ch;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  margin-right: auto;
+  margin-left: auto;
+}

--- a/test/dummy/app/views/articles/show.html.erb
+++ b/test/dummy/app/views/articles/show.html.erb
@@ -1,1 +1,3 @@
-<%= @article.content %>
+<div class="container">
+  <%= @article.content %>
+</div>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application" %>
+    <%= stylesheet_link_tag "action_markdown/action_markdown" %>
   </head>
 
   <body>

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,0 +1,9 @@
+puts "START rails db:seed"
+
+puts "Deleting old articles..."
+Article.destroy_all
+
+puts "Creating new articles..."
+Article.create! content: File.open(File.expand_path("../../fixtures/content.md", __dir__)).read
+
+puts "END rails db:seed!"

--- a/test/fixtures/content.md
+++ b/test/fixtures/content.md
@@ -1,0 +1,108 @@
+# Markdown styling
+
+This article will contain unordered lists:
+
+- First item
+- Second item
+
+It will also contain ordered lists:
+
+1. First item
+2. Second item
+
+It will also contain some `ActionMarkdown::MarkdownText` inline code in the middle of the sentence and at the end `ActiveRecord::Base`.
+
+Last but not least, code blocks are painful to style, so let's style them once and for all. Here is some Ruby code:
+
+```rb
+# frozen_string_literal: true
+
+class Article < ActiveRecord::Base
+  include ActiveModel::Model
+
+  PAGE_COUNT = 5
+
+  attr_reader :something
+
+  class << self
+    def whatever
+      return 1 + 1 if self.is_a?(Article)
+    end
+  end
+
+  def inialize(content: nil)
+    @content = content
+  end
+
+  def method
+    10.times.with_index do |index|
+      puts "Something very long to overflow overflow overflow overflow overflow overflow in the HTML"
+    end
+  end
+
+  def error
+    raise NotImplementedError, "Subclass responsibility"
+  end
+end
+```
+
+Here is some SCSS code:
+
+```scss
+// Comment
+
+:root {
+  --font-family-sans: 'Lato', -apple-system;
+  --variable: 20px;
+}
+
+@mixin media($query) {
+  @if $query == tabletAndUp {
+    @media (min-width: 50rem) { @content; }
+  }
+}
+
+.card {
+  border-radius: 1rem;
+  padding: var(--variable);
+}
+```
+
+Here is some HTML+erb:
+
+```erb
+<%# Comment %>
+
+<%= content_for :meta_title, @article.meta_title %>
+
+<h1>Articles</h1>
+
+<div class="border rounded p-3">
+  <% @articles.each do |article| %>
+    <%= render article %>
+  <% end %>
+</div>
+```
+
+Here is some JavaScript code:
+
+```js
+import { Controller } from "@hotwired/stimulus"
+import { debounce } from "../helpers/debounce_helpers"
+
+export default class extends Controller {
+  static classes = ["active"]
+
+  initialize() {
+    this.scroll = debounce(this.scroll.bind(this), 15)
+  }
+
+  scroll() {
+    if (window.scrollY >= 40) {
+      this.element.classList.add(this.activeClass)
+    } else {
+      this.element.classList.remove(this.activeClass)
+    }
+  }
+}
+```

--- a/test/models/attribute_test.rb
+++ b/test/models/attribute_test.rb
@@ -4,7 +4,7 @@ class ActionMarkdown::AttributeTest < ActionView::TestCase
   test "Instantiating an article with Markdown content converts it to HML" do
     article = Article.new content: "# Title"
 
-    assert_dom_equal %q(<h1>Title</h1>), article.content.to_s.strip
+    assert_dom_equal %q(<div class="action-markdown"> <h1>Title</h1> </div>), article.content.to_s.squish
   end
 
   test "Instanciating an article without Markdown content returns an empty string" do
@@ -14,7 +14,7 @@ class ActionMarkdown::AttributeTest < ActionView::TestCase
   test "Creating an article with Markdown content converts it to HML" do
     article = Article.create! content: "# Title"
 
-    assert_dom_equal %q(<h1>Title</h1>), article.content.to_s.strip
+    assert_dom_equal %q(<div class="action-markdown"> <h1>Title</h1> </div>), article.content.to_s.squish
   end
 
   test "Creating an article without Markdown content returns an empty string" do

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -2,14 +2,16 @@ require "test_helper"
 
 class ActionMarkdown::ContentTest < ActiveSupport::TestCase
   test "#to_html converts the Markdown body to HTML" do
-    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_html.strip
+    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_html.squish
   end
 
   test "#to_s converts the Markdown body to HTML" do
-    assert_equal %Q(<h1>Title</h1>), ActionMarkdown::Content.new("# Title").to_s.strip
+    assert_equal %Q(<div class="action-markdown"> <h1>Title</h1> </div>),
+      ActionMarkdown::Content.new("# Title").to_s.squish
   end
 
   test "#to_s properly sanitizes generated HTML" do
-    assert_equal 'alert("hello")', ActionMarkdown::Content.new('<script>alert("hello")</script>').to_s.strip
+    assert_equal '<div class="action-markdown"> alert("hello") </div>',
+      ActionMarkdown::Content.new('<script>alert("hello")</script>').to_s.squish
   end
 end


### PR DESCRIPTION
Closes #9

Styling Markdown is a pain (hello syntax highlighting!). This commit adds a default stylesheet to style Markdown content out of the box.