### PR TITLE
Save Markdown text in the database

### DIFF
--- a/lib/action_markdown/content.rb
+++ b/lib/action_markdown/content.rb
@@ -6,6 +6,10 @@ module ActionMarkdown
       @body = body
     end
 
+    def to_markdown
+      body
+    end
+
     def to_html
       markdown_renderer.render(body)
     end

--- a/lib/action_markdown/serialization.rb
+++ b/lib/action_markdown/serialization.rb
@@ -14,11 +14,11 @@ module ActionMarkdown
         when nil
           nil
         when self
-          content.to_html
+          content.to_markdown
         when ActionMarkdown::MarkdownText
-          content.body.to_html
+          content.body.to_markdown
         else
-          new(content).to_html
+          new(content).to_markdown
         end
       end
     end

--- a/test/models/attribute_test.rb
+++ b/test/models/attribute_test.rb
@@ -17,6 +17,12 @@ class ActionMarkdown::AttributeTest < ActionView::TestCase
     assert_dom_equal %q(<div class="action-markdown"> <h1>Title</h1> </div>), article.content.to_s.squish
   end
 
+  test "Creating an article saves Markdown text in the database" do
+    article = Article.create! content: "# Title"
+
+    assert_equal "# Title", article.content.body.to_markdown
+  end
+
   test "Creating an article without Markdown content returns an empty string" do
     assert_dom_equal "", Article.create!.content.to_s.strip
   end


### PR DESCRIPTION
Closes #16 

It's important to save Markdown text in the database. If it were converted to HTML in the database, then the user couldn't edit it as Markdown in edit forms.