### PR TITLE
Add markdown_area_tag form helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ In the view above, the Markdown content will automatically be converted to the f
 <p>This is a paragraph.</p>
 ```
 
+**Note**: To use a Markdown fields in forms, we should use the `markdown_field` helper like in the following example:
+
+```erb
+<%= form_with model: article do |f| %>
+  <%= f.label :content %>
+  <%= f.markdown_field :content %>
+
+  <%= f.submit "Save" %>
+<% end %>
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/helpers/action_markdown/tag_helper.rb
+++ b/app/helpers/action_markdown/tag_helper.rb
@@ -1,0 +1,37 @@
+require "action_view/helpers/tags/placeholderable"
+
+module ActionMarkdown
+  module TagHelper
+    def markdown_field_tag(name, value = nil, options = {})
+      options = options.symbolize_keys
+
+      content_tag("textarea", value, options)
+    end
+  end
+end
+
+module ActionView::Helpers
+  class Tags::ActionMarkdown < Tags::Base
+    include Tags::Placeholderable
+
+    def render
+      options = @options.stringify_keys
+      options["value"] = options.fetch("value") { value&.to_markdown }
+      add_default_name_and_id(options)
+
+      @template_object.markdown_field_tag("textarea", options["value"], options.except("value"))
+    end
+  end
+
+  module FormHelper
+    def markdown_field(object_name, method, options = {})
+      Tags::ActionMarkdown.new(object_name, method, self, options).render
+    end
+  end
+
+  class FormBuilder
+    def markdown_field(method, options = {})
+      @template.markdown_field(@object_name, method, objectify_options(options))
+    end
+  end
+end

--- a/app/models/action_markdown/markdown_text.rb
+++ b/app/models/action_markdown/markdown_text.rb
@@ -7,6 +7,7 @@ module ActionMarkdown
     belongs_to :record, polymorphic: true, touch: true
 
     delegate :to_s, :nil?, to: :body
+    delegate :to_markdown, to: :body, allow_nil: true
     delegate :blank?, :empty?, :present?, to: :to_html
 
     def to_html

--- a/lib/action_markdown/engine.rb
+++ b/lib/action_markdown/engine.rb
@@ -7,5 +7,11 @@ module ActionMarkdown
         extend ActionMarkdown::Attribute
       end
     end
+
+    initializer "action_markdown.helper" do
+      ActiveSupport.on_load(:action_controller_base) do
+        helper ActionMarkdown::Engine.helpers
+      end
+    end
   end
 end

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :set_article, only: %i[show]
+  before_action :set_article, only: %i[show edit update destroy]
 
   def index
     @articles = Article.all
@@ -20,6 +20,23 @@ class ArticlesController < ApplicationController
     else
       render :new
     end
+  end
+
+  def edit
+  end
+
+  def update
+    if @article.update(article_params)
+      redirect_to article_path(@article)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @article.destroy!
+
+    redirect_to articles_path
   end
 
   private

--- a/test/dummy/app/views/articles/_form.html.erb
+++ b/test/dummy/app/views/articles/_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_with model: article do |f| %>
+  <%= f.label :content %>
+  <%= f.markdown_field :content, style: "display: block;" %>
+
+  <%= f.submit "Save" %>
+<% end %>

--- a/test/dummy/app/views/articles/edit.html.erb
+++ b/test/dummy/app/views/articles/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit article</h1>
+
+<%= link_to "Back to article", @article %>
+
+<%= render "form", article: @article %>

--- a/test/dummy/app/views/articles/new.html.erb
+++ b/test/dummy/app/views/articles/new.html.erb
@@ -1,8 +1,5 @@
 <h1>New article</h1>
 
-<%= form_with model: @article do |f| %>
-  <%= f.label :content %>
-  <%= f.text_area :content, style: "display: block;" %>
+<%= link_to "Back to articles", articles_path %>
 
-  <%= f.submit "Save" %>
-<% end %>
+<%= render "form", article: @article %>

--- a/test/dummy/app/views/articles/show.html.erb
+++ b/test/dummy/app/views/articles/show.html.erb
@@ -1,3 +1,6 @@
+<%= link_to "Back to articles", articles_path %>
+<%= link_to "Edit article", edit_article_path(@article) %>
+
 <div class="container">
   <%= @article.content %>
 </div>

--- a/test/templates/form_helper_test.rb
+++ b/test/templates/form_helper_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class ActionMarkdown::FormHelperTest < ActionView::TestCase
+  tests ActionMarkdown::TagHelper
+
+  def form_with(*, **)
+    @output_buffer = super
+  end
+
+  teardown do
+    I18n.backend.reload!
+  end
+
+  setup do
+    I18n.backend.store_translations("placeholder",
+      activerecord: {
+        attributes: {
+          article: {
+            content: "Article content"
+          }
+        }
+      }
+    )
+  end
+
+  test "#markdown_field_tag" do
+    article = Article.new
+
+    form_with model: article do |f|
+      markdown_field_tag :content, article.content
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea>' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+      output_buffer.squish
+  end
+
+  test "form with a markdown_field" do
+    form_with model: Article.new do |f|
+      f.markdown_field :content
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea name="article[content]" id="article_content">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+
+  test "form with a markdown_field and a custom class" do
+    form_with model: Article.new do |f|
+      f.markdown_field :content, class: "custom-class"
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea name="article[content]" id="article_content" class="custom-class">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+
+  test "form with markdown_field for non-attribute" do
+    form_with model: Article.new do |f|
+      f.markdown_field :not_an_attribute
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea name="article[not_an_attribute]" id="article_not_an_attribute">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+
+  test "modelless form with markdown_field" do
+    form_with url: "/articles" do |f|
+      f.markdown_field :content
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea name="content" id="content">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+      output_buffer.squish
+  end
+
+  test "form with markdown_field having placeholder without locale" do
+    form_with model: Article.new do |f|
+      f.markdown_field :content, placeholder: true
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea placeholder="Content" name="article[content]" id="article_content">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+
+  test "form with markdown_field having placeholder with locale" do
+    I18n.with_locale :placeholder do
+      form_with model: Article.new do |f|
+        f.markdown_field :content, placeholder: true
+      end
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea placeholder="Article content" name="article[content]" id="article_content">' \
+          ' ' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+
+  test "form with markdown_field with value" do
+    form_with model: Article.new do |f|
+      f.markdown_field :content, value: "# Title"
+    end
+
+    assert_dom_equal \
+      '<form action="/articles" accept-charset="UTF-8" method="post">' \
+        '<textarea name="article[content]" id="article_content">' \
+          ' # Title' \
+        '</textarea>' \
+      '</form>',
+    output_buffer.squish
+  end
+end


### PR DESCRIPTION
Closes #18 

In this PR, we create the `markdown_text_area` form helper and the `markdown_area_tag` tag to generate the markdown field `textarea` and populate it with the right value automatically.
