### PR TITLE
Move Rails engine hooks into after_initialize

### DIFF
--- a/lib/action_markdown/engine.rb
+++ b/lib/action_markdown/engine.rb
@@ -3,14 +3,18 @@ module ActionMarkdown
     isolate_namespace ActionMarkdown
 
     initializer "action_markdown.attribute" do
-      ActiveSupport.on_load(:active_record) do
-        extend ActionMarkdown::Attribute
+      config.after_initialize do
+        ActiveSupport.on_load(:active_record) do
+          extend ActionMarkdown::Attribute
+        end
       end
     end
 
     initializer "action_markdown.helper" do
-      ActiveSupport.on_load(:action_controller_base) do
-        helper ActionMarkdown::Engine.helpers
+      config.after_initialize do
+        ActiveSupport.on_load(:action_controller_base) do
+          helper ActionMarkdown::Engine.helpers
+        end
       end
     end
   end


### PR DESCRIPTION
## What 

Move Rails engine hooks into `after_initialize`

## Why

After adding `action_markdown` to a Rails 7.1 application that was already using [sorcery](https://github.com/Sorcery/sorcery) the application would raise an error at startup.

```
active_support/inflector/methods.rb:290:in `const_get': uninitialized constant ActionMarkdown::TagHelper (NameError)

      Object.const_get(camel_cased_word)
            ^^^^^^^^^^
```

To be fair action_markdown works fine with stock Rails 7.1, and socery is known https://github.com/Sorcery/sorcery/issues/308#issuecomment-1107680260 to have Rails 7 compatibility problems.  But hopefully this will at save someone a couple hours if they run into the same problem.
