### PR TITLE
Silence Rails 7.2 deprecation warning

### DIFF
--- a/app/models/action_markdown/markdown_text.rb
+++ b/app/models/action_markdown/markdown_text.rb
@@ -2,8 +2,8 @@ module ActionMarkdown
   class MarkdownText < ApplicationRecord
     self.table_name = "action_markdown_markdown_texts"
 
-    serialize :body, ActionMarkdown::Content
-
+    serialize :body, coder: ActionMarkdown::Content
+    
     belongs_to :record, polymorphic: true, touch: true
 
     delegate :to_s, :nil?, to: :body


### PR DESCRIPTION
This commit updates the use of the `serialize` macro in `markdown_text.rb` and silences the Rails 7.2 deprecation warning.